### PR TITLE
feat: wrapped governance token

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Contributions are welcome! Please read our contributing guidelines to get starte
 
 License 📄
 
-This project is licensed under AGPL-3.0-or-later.
+This project is MIT licensed
 
 Support 💬
 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -11,9 +11,13 @@ import {PluginRepoFactory} from "@aragon/osx/framework/plugin/repo/PluginRepoFac
 import {PluginRepo} from "@aragon/osx/framework/plugin/repo/PluginRepo.sol";
 import {PluginSetupRef} from "@aragon/osx/framework/plugin/setup/PluginSetupProcessorHelpers.sol";
 import {GovernanceERC20} from "@aragon/token-voting-plugin/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from
+    "@aragon/token-voting-plugin/ERC20/governance/GovernanceWrappedERC20.sol";
 
 import {IVotesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
+import {IERC20Upgradeable} from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 import {MaciVoting} from "../src/MaciVoting.sol";
 import {MaciVotingSetup} from "../src/MaciVotingSetup.sol";
@@ -79,16 +83,19 @@ contract MaciVotingScript is Script {
     }
 
     function deployPluginSetup() public returns (MaciVotingSetup) {
-        // this ERC20 is just a placeholder, it will be cloned with token
-        // and mint settings from Utils
-        GovernanceERC20 tokenToClone = new GovernanceERC20(
-            IDAO(address(0x0)),
+        // GovernanceERC20 and GovernanceWrappedERC20 are implementation contracts. If one is
+        // required, it will be cloned with token and mint settings from Utils
+        GovernanceERC20 governanceERC20Base = new GovernanceERC20(
+            IDAO(address(0)),
             "",
             "",
             GovernanceERC20.MintSettings({receivers: new address[](0), amounts: new uint256[](0)})
         );
+        GovernanceWrappedERC20 governanceWrappedERC20Base =
+            new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "");
         address maciVoting = address(new MaciVoting());
-        MaciVotingSetup pluginSetup = new MaciVotingSetup(tokenToClone, maciVoting);
+        MaciVotingSetup pluginSetup =
+            new MaciVotingSetup(governanceERC20Base, governanceWrappedERC20Base, maciVoting);
         return pluginSetup;
     }
 

--- a/script/Utils.sol
+++ b/script/Utils.sol
@@ -91,9 +91,9 @@ library Utils {
             mintSettings.amounts[i] = amount;
         }
 
-        GovernanceERC20 tokenToClone = new GovernanceERC20(
+        GovernanceERC20 governanceERC20Base = new GovernanceERC20(
             IDAO(address(0x0)), tokenSettings.name, tokenSettings.symbol, mintSettings
         );
-        return (tokenToClone, tokenSettings, mintSettings);
+        return (governanceERC20Base, tokenSettings, mintSettings);
     }
 }

--- a/src/MaciVotingSetup.sol
+++ b/src/MaciVotingSetup.sol
@@ -3,8 +3,11 @@
 pragma solidity ^0.8.29;
 
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IVotesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
+import {IERC20Upgradeable} from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
 import {
@@ -15,6 +18,8 @@ import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
 import {GovernanceERC20} from "@aragon/token-voting-plugin/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from
+    "@aragon/token-voting-plugin/ERC20/governance/GovernanceWrappedERC20.sol";
 
 import {IMaciVoting} from "./IMaciVoting.sol";
 import {MaciVoting} from "./MaciVoting.sol";
@@ -23,11 +28,20 @@ import {MaciVoting} from "./MaciVoting.sol";
 /// @dev Release 1, Build 1
 // @custom:oz-upgrades-unsafe-allow state-variable-immutable
 contract MaciVotingSetup is PluginSetup {
+    using Address for address;
     using Clones for address;
     using ProxyLib for address;
 
+    /// @notice The address of the `MaciVoting` base contract.
+    // solhint-disable-next-line immutable-vars-naming
+    MaciVoting private immutable maciVotingBase;
+
     /// @notice The address of the `GovernanceERC20` base contract.
     address public immutable governanceERC20Base;
+
+    /// @notice The address of the `GovernanceWrappedERC20` base contract.
+    // solhint-disable-next-line immutable-vars-naming
+    address public immutable governanceWrappedERC20Base;
 
     /// @notice Configuration settings for a token used within the governance system.
     /// @param addr The token address. If set to `address(0)`, a new
@@ -42,31 +56,30 @@ contract MaciVotingSetup is PluginSetup {
         string symbol;
     }
 
-    /// @notice Constructs the `PluginSetup` by storing the `MaciVoting` implementation address.
+    /// @notice Thrown if the passed token address is not a token contract.
+    /// @param token The token address
+    error TokenNotContract(address token);
+
+    /// @notice Thrown if token address is not ERC20.
+    /// @param token The token address
+    error TokenNotERC20(address token);
+
+    /// @notice The contract constructor deploying the plugin implementation contract
+    ///     and receiving the governance token base contracts to clone from.
     /// @dev The implementation address is used to deploy UUPS proxies referencing it and
     /// to verify the plugin on the respective block explorers.
-    constructor(GovernanceERC20 _governanceERC20Base, address _maciVoting)
-        PluginSetup(_maciVoting)
-    {
+    /// @param _governanceERC20Base The base `GovernanceERC20` contract to create clones from.
+    /// @param _governanceWrappedERC20Base The base `GovernanceWrappedERC20` contract to create
+    /// clones from.
+    /// @param _maciVoting The base `MaciVoting` implementation address
+    constructor(
+        GovernanceERC20 _governanceERC20Base,
+        GovernanceWrappedERC20 _governanceWrappedERC20Base,
+        address _maciVoting
+    ) PluginSetup(_maciVoting) {
+        maciVotingBase = MaciVoting(IMPLEMENTATION);
         governanceERC20Base = address(_governanceERC20Base);
-    }
-
-    function _deployToken(
-        address _dao,
-        TokenSettings memory tokenSettings,
-        GovernanceERC20.MintSettings memory mintSettings
-    ) internal returns (address token) {
-        token = governanceERC20Base.clone();
-        GovernanceERC20(token).initialize(
-            IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings
-        );
-    }
-
-    function _deployPlugin(IMaciVoting.InitializationParams memory _params)
-        internal
-        returns (address plugin_)
-    {
-        plugin_ = IMPLEMENTATION.deployUUPSProxy(abi.encodeCall(MaciVoting.initialize, _params));
+        governanceWrappedERC20Base = address(_governanceWrappedERC20Base);
     }
 
     /// @inheritdoc IPluginSetup
@@ -74,6 +87,8 @@ contract MaciVotingSetup is PluginSetup {
         external
         returns (address plugin, PreparedSetupData memory preparedSetupData)
     {
+        // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting`
+        // plugin, and the required helpers
         (
             IMaciVoting.InitializationParams memory _params,
             TokenSettings memory tokenSettings,
@@ -82,14 +97,46 @@ contract MaciVotingSetup is PluginSetup {
             _data, (IMaciVoting.InitializationParams, TokenSettings, GovernanceERC20.MintSettings)
         );
 
-        address token = _deployToken(_dao, tokenSettings, mintSettings);
+        address token = tokenSettings.addr;
+
+        if (tokenSettings.addr != address(0)) {
+            if (!token.isContract()) {
+                revert TokenNotContract(token);
+            }
+
+            if (!_isERC20(token)) {
+                revert TokenNotERC20(token);
+            }
+
+            if (!supportsIVotesInterface(token)) {
+                token = governanceWrappedERC20Base.clone();
+                // User already has a token. We need to wrap it in
+                // GovernanceWrappedERC20 in order to make the token
+                // include governance functionality.
+                GovernanceWrappedERC20(token).initialize(
+                    IERC20Upgradeable(tokenSettings.addr), tokenSettings.name, tokenSettings.symbol
+                );
+            }
+        } else {
+            // Clone a `GovernanceERC20`.
+            token = governanceERC20Base.clone();
+            GovernanceERC20(token).initialize(
+                IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings
+            );
+        }
 
         _params.dao = IDAO(_dao);
         _params.token = IVotesUpgradeable(token);
 
-        plugin = _deployPlugin(_params);
+        // Prepare and deploy plugin proxy.
+        plugin =
+            address(maciVotingBase).deployUUPSProxy(abi.encodeCall(MaciVoting.initialize, _params));
 
-        preparedSetupData.permissions = new PermissionLib.MultiTargetPermission[](2);
+        // Prepare permissions
+        preparedSetupData.permissions =
+            new PermissionLib.MultiTargetPermission[](tokenSettings.addr != address(0) ? 2 : 3);
+
+        // Grant the `EXECUTE_PERMISSION` on the DAO to the plugin
         preparedSetupData.permissions[0] = PermissionLib.MultiTargetPermission({
             operation: PermissionLib.Operation.Grant,
             where: _dao,
@@ -98,6 +145,7 @@ contract MaciVotingSetup is PluginSetup {
             permissionId: DAO(payable(_dao)).EXECUTE_PERMISSION_ID()
         });
 
+        // Grant the `CHANGE_COORDINATOR_PUBLIC_KEY_PERMISSION_ID` on the plugin to the DAO
         preparedSetupData.permissions[1] = PermissionLib.MultiTargetPermission({
             operation: PermissionLib.Operation.Grant,
             where: plugin,
@@ -105,6 +153,18 @@ contract MaciVotingSetup is PluginSetup {
             condition: PermissionLib.NO_CONDITION,
             permissionId: MaciVoting(plugin).CHANGE_COORDINATOR_PUBLIC_KEY_PERMISSION_ID()
         });
+
+        if (tokenSettings.addr == address(0)) {
+            bytes32 tokenMintPermission = GovernanceERC20(token).MINT_PERMISSION_ID();
+
+            preparedSetupData.permissions[2] = PermissionLib.MultiTargetPermission({
+                operation: PermissionLib.Operation.Grant,
+                where: token,
+                who: _dao,
+                condition: PermissionLib.NO_CONDITION,
+                permissionId: tokenMintPermission
+            });
+        }
     }
 
     /// @inheritdoc IPluginSetup
@@ -130,5 +190,33 @@ contract MaciVotingSetup is PluginSetup {
             condition: PermissionLib.NO_CONDITION,
             permissionId: MaciVoting(_payload.plugin).CHANGE_COORDINATOR_PUBLIC_KEY_PERMISSION_ID()
         });
+    }
+
+    /// @notice Unsatisfiably determines if the token is an IVotes interface.
+    /// @dev Many tokens don't use ERC165 even though they still support IVotes.
+    function supportsIVotesInterface(address token) public view returns (bool) {
+        (bool success1, bytes memory data1) = token.staticcall(
+            abi.encodeWithSelector(IVotesUpgradeable.getPastTotalSupply.selector, 0)
+        );
+        (bool success2, bytes memory data2) = token.staticcall(
+            abi.encodeWithSelector(IVotesUpgradeable.getVotes.selector, address(this))
+        );
+        (bool success3, bytes memory data3) = token.staticcall(
+            abi.encodeWithSelector(IVotesUpgradeable.getPastVotes.selector, address(this), 0)
+        );
+
+        return (
+            success1 && data1.length == 0x20 && success2 && data2.length == 0x20 && success3
+                && data3.length == 0x20
+        );
+    }
+
+    /// @notice Unsatisfiably determines if the contract is an ERC20 token.
+    /// @dev It's important to first check whether token is a contract prior to this call.
+    /// @param token The token address
+    function _isERC20(address token) private view returns (bool) {
+        (bool success, bytes memory data) =
+            token.staticcall(abi.encodeCall(IERC20Upgradeable.balanceOf, (address(this))));
+        return success && data.length == 0x20;
     }
 }

--- a/test/MaciVotingE2E.t.sol
+++ b/test/MaciVotingE2E.t.sol
@@ -1,12 +1,17 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
 import {PluginRepo} from "@aragon/osx/framework/plugin/repo/PluginRepo.sol";
+import {GovernanceERC20} from "@aragon/token-voting-plugin/ERC20/governance/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from
+    "@aragon/token-voting-plugin/ERC20/governance/GovernanceWrappedERC20.sol";
+
 import {IVotesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
-import {GovernanceERC20} from "@aragon/token-voting-plugin/ERC20/governance/GovernanceERC20.sol";
+import {IERC20Upgradeable} from
+    "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 import {AragonE2E} from "./base/AragonE2E.sol";
 import {MaciVotingSetup} from "../src/MaciVotingSetup.sol";
@@ -25,13 +30,15 @@ contract MaciVotingE2E is AragonE2E {
         super.setUp();
 
         (
-            GovernanceERC20 tokenToClone,
+            GovernanceERC20 governanceERC20Base,
             MaciVotingSetup.TokenSettings memory tokenSettings,
             GovernanceERC20.MintSettings memory mintSettings
         ) = Utils.getGovernanceTokenAndMintSettings();
+        GovernanceWrappedERC20 governanceWrappedERC20Base =
+            new GovernanceWrappedERC20(IERC20Upgradeable(address(0)), "", "");
         address maciVoting = address(new MaciVoting());
 
-        setup = new MaciVotingSetup(tokenToClone, maciVoting);
+        setup = new MaciVotingSetup(governanceERC20Base, governanceWrappedERC20Base, maciVoting);
         address _plugin;
 
         Utils.MaciEnvVariables memory maciEnvVariables = Utils.readMaciEnv();

--- a/test/base/AragonE2E.sol
+++ b/test/base/AragonE2E.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
 /* solhint-disable no-console */

--- a/test/base/AragonTest.sol
+++ b/test/base/AragonTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
 import {Test} from "forge-std/Test.sol";


### PR DESCRIPTION
**What does this PR do?**
* Supports wrapped governance tokens - this brings our plugin in line with the functionality of the official Aragon [token voting plugin](https://github.com/aragon/token-voting-plugin)
    * The way this works is that if a developer supplies a voting token for the plugin, but it is not compatible with `ERC20Votes`, the token will be wrapped and given governance capabilities


**How to review this PR**
* for `MaciVotingSetup`, you can compare these changes against [TokenVotingSetup](https://github.com/aragon/token-voting-plugin/blob/main/packages/contracts/src/TokenVotingSetup.sol) in the token voting plugin repo. A lot of the logic is just copied over.
* Compare the unit test to the following [hardhat test](https://github.com/aragon/token-voting-plugin/blob/b20983c1a69b82a14b243b6415cc165b6b223858/packages/contracts/test/10_unit-testing/12_plugin-setup.ts#L467-L546). It is roughly equivalent    