### PR TITLE
feat: support ERC165

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -6,10 +6,8 @@
     "func-name-mixedcase": "off",
     "func-visibility": ["error", { "ignoreConstructors": true }],
     "max-line-length": ["error", 100],
-    "named-parameters-mapping": "off",
     "not-rely-on-time": "off",
     "one-contract-per-file": "off",
-    "immutable-vars-naming": "off",
     "import-path-check": "off"
   }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -129,6 +129,7 @@ contract MaciVotingScript is Script {
             maci: maciEnvVariables.maci,
             coordinatorPublicKey: maciEnvVariables.coordinatorPublicKey,
             votingSettings: maciEnvVariables.votingSettings,
+            targetConfig: maciEnvVariables.targetConfig,
             verifier: maciEnvVariables.verifier,
             verifyingKeysRegistry: maciEnvVariables.verifyingKeysRegistry,
             policyFactory: maciEnvVariables.policyFactory,

--- a/script/Utils.sol
+++ b/script/Utils.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.29;
 
 import {Vm} from "forge-std/Test.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IPlugin} from "@aragon/osx-commons-contracts/src/plugin/IPlugin.sol";
 import {DomainObjs} from "@maci-protocol/contracts/contracts/utilities/DomainObjs.sol";
 import {Params} from "@maci-protocol/contracts/contracts/utilities/Params.sol";
 import {GovernanceERC20} from "@aragon/token-voting-plugin/ERC20/governance/GovernanceERC20.sol";
@@ -18,6 +19,7 @@ library Utils {
         address maci;
         DomainObjs.PublicKey coordinatorPublicKey;
         IMaciVoting.VotingSettings votingSettings;
+        IPlugin.TargetConfig targetConfig;
         address verifier;
         address verifyingKeysRegistry;
         address policyFactory;
@@ -41,6 +43,9 @@ library Utils {
     }
 
     function readMaciEnv() public view returns (MaciEnvVariables memory maciEnvVariables) {
+        IPlugin.TargetConfig memory defaultTargetConfig =
+            IPlugin.TargetConfig({target: address(0), operation: IPlugin.Operation.Call});
+
         maciEnvVariables.maci = VM.envAddress("MACI_ADDRESS");
         maciEnvVariables.coordinatorPublicKey = DomainObjs.PublicKey({
             x: VM.envUint("COORDINATOR_PUBLIC_KEY_X"),
@@ -53,6 +58,7 @@ library Utils {
             uint8(VM.envUint("VOTE_OPTIONS")),
             parseMode(VM.envString("MODE"))
         );
+        maciEnvVariables.targetConfig = defaultTargetConfig;
         maciEnvVariables.verifier = VM.envAddress("VERIFIER_ADDRESS");
         maciEnvVariables.verifyingKeysRegistry = VM.envAddress("VERIFYING_KEY_REGISTRY_ADDRESS");
         maciEnvVariables.policyFactory = VM.envAddress("POLICY_FACTORY_ADDRESS");

--- a/src/IMaciVoting.sol
+++ b/src/IMaciVoting.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.29;
 
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {Action} from "@aragon/osx-commons-contracts/src/executors/IExecutor.sol";
+import {IPlugin} from "@aragon/osx-commons-contracts/src/plugin/IPlugin.sol";
+
 import {IVotesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
 
@@ -15,6 +18,7 @@ interface IMaciVoting {
         address maci;
         DomainObjs.PublicKey coordinatorPublicKey;
         VotingSettings votingSettings;
+        IPlugin.TargetConfig targetConfig;
         address verifier;
         address verifyingKeysRegistry;
         address policyFactory;
@@ -24,6 +28,13 @@ interface IMaciVoting {
         uint8 messageBatchSize;
     }
 
+    /// @notice A struct containing the voting settings for proposals.
+    /// @param minParticipation The minimum participation value.
+    ///     Its value has to be in the interval [0, 10^6] defined by `RATIO_BASE = 10**6`.
+    /// @param minDuration The minimum duration of the proposal vote in seconds.
+    /// @param minProposerVotingPower The minimum voting power required to create a proposal.
+    /// @param voteOptions The number of voting options available in the poll.
+    /// @param mode The MACI mode for the poll (either QV, NON_QV, or FULL).
     struct VotingSettings {
         uint32 minParticipation;
         uint64 minDuration;
@@ -31,4 +42,72 @@ interface IMaciVoting {
         uint8 voteOptions;
         DomainObjs.Mode mode;
     }
+
+    /// @notice A container for the results of the voting. We read from the poll and
+    /// store the results here.
+    /// @param yes The number of votes for the "yes" option.
+    /// @param no The number of votes for the "no" option.
+    /// @param abstain The number of votes for the "abstain" option.
+    struct TallyResults {
+        uint256 yes;
+        uint256 no;
+        uint256 abstain;
+    }
+
+    // @notice Tally results struct that is implementd in Tally but not defined
+    // in the interface ITally
+    // @param flag Whether the tally value was initialized or not
+    // @param value The tally value of an option
+    struct TallyResult {
+        bool flag;
+        uint256 value;
+    }
+
+    /// @notice A container for the proposal parameters at the time of proposal creation.
+    /// @param startDate The start date of the proposal vote.
+    /// @param endDate The end date of the proposal vote.
+    /// @param snapshotBlock The number of the block prior to the proposal creation.
+    /// @param minVotingPower The minimum voting power needed.
+    struct ProposalParameters {
+        uint64 startDate;
+        uint64 endDate;
+        uint256 snapshotBlock;
+        uint256 minVotingPower;
+    }
+
+    /// @notice A container for proposal-related information.
+    /// @param executed Whether the proposal is executed or not.
+    /// @param parameters The proposal parameters at the time of the proposal creation.
+    /// @param actions The actions to be executed when the proposal passes.
+    /// @param allowFailureMap A bitmap allowing the proposal to succeed, even if individual
+    /// actions might revert. If the bit at index `i` is 1, the proposal succeeds even if the `i`th
+    /// action reverts. A failure map value of 0 requires every action to not revert.
+    /// @param targetConfig Configuration for the execution target, specifying the target address
+    /// and operation type (either `Call` or `DelegateCall`). Defined by `TargetConfig` in the
+    /// `IPlugin` interface,
+    ///     part of the `osx-commons-contracts` package, added in build 3.
+    /// @param pollId The ID of the MACI poll
+    /// @param pollAddress The address of the MACI poll
+    struct Proposal {
+        bool executed;
+        ProposalParameters parameters;
+        TallyResults tally;
+        Action[] actions;
+        uint256 allowFailureMap;
+        // TODO: #24 (merge-ok) decide whether to include minApprovalPower and other
+        // IMajorityVoting functionality
+        // uint256 minApprovalPower;
+        IPlugin.TargetConfig targetConfig;
+        uint256 pollId;
+        address pollAddress;
+    }
+
+    function minProposerVotingPower() external view returns (uint256);
+    function totalVotingPower(uint256 _blockNumber) external view returns (uint256);
+    function getVotingToken() external view returns (IVotesUpgradeable);
+    function minParticipation() external view returns (uint32);
+    function minDuration() external view returns (uint64);
+    function getProposal(uint256 _proposalId) external view returns (Proposal memory proposal_);
+    function changeCoordinatorPublicKey(DomainObjs.PublicKey calldata _coordinatorPublicKey)
+        external;
 }

--- a/src/MaciVotingSetup.sol
+++ b/src/MaciVotingSetup.sol
@@ -37,6 +37,7 @@ contract MaciVotingSetup is PluginSetup {
     MaciVoting private immutable maciVotingBase;
 
     /// @notice The address of the `GovernanceERC20` base contract.
+    // solhint-disable-next-line immutable-vars-naming
     address public immutable governanceERC20Base;
 
     /// @notice The address of the `GovernanceWrappedERC20` base contract.
@@ -92,6 +93,7 @@ contract MaciVotingSetup is PluginSetup {
         (
             IMaciVoting.InitializationParams memory _params,
             TokenSettings memory tokenSettings,
+            // only used for GovernanceERC20(token is not passed)
             GovernanceERC20.MintSettings memory mintSettings
         ) = abi.decode(
             _data, (IMaciVoting.InitializationParams, TokenSettings, GovernanceERC20.MintSettings)
@@ -154,6 +156,7 @@ contract MaciVotingSetup is PluginSetup {
             permissionId: MaciVoting(plugin).CHANGE_COORDINATOR_PUBLIC_KEY_PERMISSION_ID()
         });
 
+        // Grant the `MINT_PERMISSION_ID` on the token to the DAO if deploying a new token
         if (tokenSettings.addr == address(0)) {
             bytes32 tokenMintPermission = GovernanceERC20(token).MINT_PERMISSION_ID();
 

--- a/test/MaciVoting.t.sol
+++ b/test/MaciVoting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.29;
 
 import {IVotesUpgradeable} from
     "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
@@ -56,6 +56,7 @@ abstract contract MaciVotingTest is AragonTest {
             maci: maciEnvVariables.maci,
             coordinatorPublicKey: maciEnvVariables.coordinatorPublicKey,
             votingSettings: maciEnvVariables.votingSettings,
+            targetConfig: maciEnvVariables.targetConfig,
             verifier: maciEnvVariables.verifier,
             verifyingKeysRegistry: maciEnvVariables.verifyingKeysRegistry,
             policyFactory: maciEnvVariables.policyFactory,
@@ -121,6 +122,7 @@ contract MaciVotingInitializeTest is MaciVotingTest {
             maci: maciEnvVariables.maci,
             coordinatorPublicKey: maciEnvVariables.coordinatorPublicKey,
             votingSettings: maciEnvVariables.votingSettings,
+            targetConfig: maciEnvVariables.targetConfig,
             verifier: maciEnvVariables.verifier,
             verifyingKeysRegistry: maciEnvVariables.verifyingKeysRegistry,
             policyFactory: maciEnvVariables.policyFactory,

--- a/test/MaciVotingE2E.t.sol
+++ b/test/MaciVotingE2E.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.29;
 
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
@@ -48,6 +48,7 @@ contract MaciVotingE2E is AragonE2E {
             maci: maciEnvVariables.maci,
             coordinatorPublicKey: maciEnvVariables.coordinatorPublicKey,
             votingSettings: maciEnvVariables.votingSettings,
+            targetConfig: maciEnvVariables.targetConfig,
             verifier: maciEnvVariables.verifier,
             verifyingKeysRegistry: maciEnvVariables.verifyingKeysRegistry,
             policyFactory: maciEnvVariables.policyFactory,

--- a/test/base/AragonE2E.sol
+++ b/test/base/AragonE2E.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.29;
 
 /* solhint-disable no-console */
 

--- a/test/base/AragonTest.sol
+++ b/test/base/AragonTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.29;
+pragma solidity ^0.8.29;
 
 import {Test} from "forge-std/Test.sol";
 import {


### PR DESCRIPTION
**What does this PR do:**
- Better support ERC165
    - Define interface selector according to the [ERC](https://eips.ethereum.org/EIPS/eip-165) - _"We define the interface identifier as the XOR of all function selectors in the interface"_
    - We don't need to add selectors from other interfaces such as `IProposal` - those selectors are defined in the interface identifier in `ProposalUpgradeable`
    - In order to define all functions in the interface, I had to move struct definitions to the interface file - `getProposal` required access to the `Proposal` struct. There is an argument that you should define as much as possible in one file to avoid context switching (and even [avoiding interfaces](https://github.com/coinbase/solidity-style-guide?tab=readme-ov-file#b-avoid-writing-interfaces)) - open to other options but followed the same pattern as Aragon for now.  
- add VOICE_CREDIT_FACTOR constant
- Update natspec
- Move & update structs
- Add targetConfig to setup config
- Add reserved spaces for OpenZeppelin v4 support
- Add TODO [#24](https://github.com/privacy-scaling-explorations/maci-voting-plugin-aragon/issues/24)